### PR TITLE
Add write gorelease write permissions

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The last attempted goreleaser run ended in an error:
```
⨯ release failed after 42.70s error=scm releases: failed to publish artifacts: POST https://api.github.com/repos/hpcng/sif/releases: 403 Resource not accessible by integration []
```
goreleaser/goreleaser#2642 indicates that may have been because of missing "permissions: contents: write" and the [documentation](https://goreleaser.com/ci/actions) also indicates that should be there but it was missing.