### PR TITLE
Merge sylabs/sif through v2.4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,5 +53,8 @@ jobs:
           flags: unittests
           name: codecov
 
+      - name: Install syft
+        run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+
       - name: Test Release
         run: curl -sL https://git.io/goreleaser | bash -s -- --snapshot --skip-publish

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           go-version: 1.17.x
 
+      -name: Install syft
+       run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -69,3 +69,6 @@ archives:
   - id: linux-archives
     builds:
       - linux-builds
+
+sboms:
+  - artifacts: archive


### PR DESCRIPTION
This pulls in the following PR, bringing apptainer/sif up to the level of v2.4.2
- sylabs/sif#196