### PR TITLE
Remove v1 branch from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,4 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  target-branch: v1
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: daily
   target-branch: main


### PR DESCRIPTION
Nothing actively supported depends on v1 anymore.