### PR TITLE
Update goreleaser to go 1.19

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.19.x
 
       - name: Install syft
         run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin


### PR DESCRIPTION
This will hopefully fix the error seen during the [first try](https://github.com/apptainer/sif/actions/runs/4409629742/jobs/7726153951) to tag 2.11.0.