### PR TITLE
Merge sylabs/sif through v2.13.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.53
+          version: v1.54
           skip-pkg-cache: true
           skip-build-cache: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.20.x'
+          go-version: '1.21.x'
 
       - name: Check go.mod and go.sum are tidy
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,9 +56,5 @@ linters:
     - whitespace
 
 linters-settings:
-  errorlint:
-    # Go 1.19 compatibility (https://github.com/sylabs/sif/issues/265).
-    errorf-multi: false
-
   misspell:
     locale: US

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/apptainer/sif/v2
 go 1.20
 
 require (
-	github.com/ProtonMail/go-crypto v0.0.0-20230710112148-e01326fd72eb
+	github.com/ProtonMail/go-crypto v0.0.0-20230717121422-5aa5874ade95
 	github.com/google/go-containerregistry v0.16.1
 	github.com/google/uuid v1.3.1
 	github.com/sebdah/goldie/v2 v2.5.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/apptainer/sif/v2
 
-go 1.19
+go 1.20
 
 require (
 	github.com/ProtonMail/go-crypto v0.0.0-20230710112148-e01326fd72eb

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/ProtonMail/go-crypto v0.0.0-20230710112148-e01326fd72eb h1:RU+Ff2vE68zFQSoBqlb/LChFztEWWJ9EZ8LU4gA3ubU=
-github.com/ProtonMail/go-crypto v0.0.0-20230710112148-e01326fd72eb/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
+github.com/ProtonMail/go-crypto v0.0.0-20230717121422-5aa5874ade95 h1:KLq8BE0KwCL+mmXnjLWEAOYO+2l2AE4YMmqG1ZpZHBs=
+github.com/ProtonMail/go-crypto v0.0.0-20230717121422-5aa5874ade95/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=

--- a/pkg/integrity/digest.go
+++ b/pkg/integrity/digest.go
@@ -121,7 +121,7 @@ func (d digest) MarshalJSON() ([]byte, error) {
 func (d *digest) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
-		return fmt.Errorf("%w: %v", errDigestMalformed, err)
+		return fmt.Errorf("%w: %w", errDigestMalformed, err)
 	}
 
 	parts := strings.Split(s, ":")
@@ -133,7 +133,7 @@ func (d *digest) UnmarshalJSON(data []byte) error {
 
 	v, err := hex.DecodeString(value)
 	if err != nil {
-		return fmt.Errorf("%w: %v", errDigestMalformed, err)
+		return fmt.Errorf("%w: %w", errDigestMalformed, err)
 	}
 
 	for h, n := range supportedDigestAlgorithms {

--- a/pkg/integrity/dsse.go
+++ b/pkg/integrity/dsse.go
@@ -129,7 +129,7 @@ func (de *dsseDecoder) verifyMessage(ctx context.Context, r io.Reader, h crypto.
 
 	vr.aks, err = v.Verify(ctx, &e)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", errDSSEVerifyEnvelopeFailed, err)
+		return nil, fmt.Errorf("%w: %w", errDSSEVerifyEnvelopeFailed, err)
 	}
 
 	if e.PayloadType != de.payloadType {

--- a/pkg/integrity/metadata.go
+++ b/pkg/integrity/metadata.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -44,7 +44,6 @@ func (e *DescriptorIntegrityError) Error() string {
 // Is compares e against target. If target is a DescriptorIntegrityError and matches e or target
 // has a zero value ID, true is returned.
 func (e *DescriptorIntegrityError) Is(target error) bool {
-	//nolint:errorlint // don't compare wrapped errors in Is()
 	t, ok := target.(*DescriptorIntegrityError)
 	if !ok {
 		return false
@@ -67,7 +66,6 @@ func (e *ObjectIntegrityError) Error() string {
 // Is compares e against target. If target is a ObjectIntegrityError and matches e or target has a
 // zero value ID, true is returned.
 func (e *ObjectIntegrityError) Is(target error) bool {
-	//nolint:errorlint // don't compare wrapped errors in Is()
 	t, ok := target.(*ObjectIntegrityError)
 	if !ok {
 		return false

--- a/pkg/integrity/select.go
+++ b/pkg/integrity/select.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -72,7 +72,6 @@ func (e *SignatureNotFoundError) Error() string {
 // Is compares e against target. If target is a SignatureNotFoundError and matches e or target has
 // a zero value ID, true is returned.
 func (e *SignatureNotFoundError) Is(target error) bool {
-	//nolint:errorlint // don't compare wrapped errors in Is()
 	t, ok := target.(*SignatureNotFoundError)
 	if !ok {
 		return false

--- a/pkg/integrity/verify.go
+++ b/pkg/integrity/verify.go
@@ -63,7 +63,6 @@ func (e *SignatureNotValidError) Unwrap() error {
 // Is compares e against target. If target is a SignatureNotValidError and matches e or target has
 // a zero value ID, true is returned.
 func (e *SignatureNotValidError) Is(target error) bool {
-	//nolint:errorlint // don't compare wrapped errors in Is()
 	t, ok := target.(*SignatureNotValidError)
 	if !ok {
 		return false

--- a/pkg/sif/descriptor_input.go
+++ b/pkg/sif/descriptor_input.go
@@ -115,7 +115,6 @@ func (e *unexpectedDataTypeError) Error() string {
 }
 
 func (e *unexpectedDataTypeError) Is(target error) bool {
-	//nolint:errorlint // don't compare wrapped errors in Is()
 	t, ok := target.(*unexpectedDataTypeError)
 	if !ok {
 		return false


### PR DESCRIPTION
This brings apptainer/sif up to date with sylabs sif v12.13.0, pulling in changes from
- sylabs/sif#317
- sylabs/sif#318
- sylabs/sif#319
- sylabs/sif#321
which addressed issues
- sylabs/sif#265

Original commit descriptions were:
> Bump module Go version to 1.20. Advance Go range tested in CI to 1.20-1.21. (Re-)adopt [multi-error wrapping](https://tip.golang.org/doc/go1.20#errors) in a couple of locations.

> As of v1.4.4, go-errorlint exempts `Is` methods from type assertions (see [polyfloyd/go-errorlint#50](https://github.com/polyfloyd/go-errorlint/issues/50)).