### PR TITLE
Update to sylabs/sif v2.15.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.54
+          version: v1.56
           skip-pkg-cache: true
           skip-build-cache: true
 

--- a/cmd/siftool/siftool.go
+++ b/cmd/siftool/siftool.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2024, Sylabs Inc. All rights reserved.
 // Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 // Copyright (c) 2017, Yannick Cote <yhcote@gmail.com> All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -61,7 +61,7 @@ func getVersion() *cobra.Command {
 		Short: "Display version information",
 		Long:  "Display binary version, build info and compatible SIF version(s).",
 		Args:  cobra.ExactArgs(0),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return writeVersion(cmd.OutOrStdout())
 		},
 		DisableFlagsInUseLine: true,

--- a/pkg/integrity/verify_test.go
+++ b/pkg/integrity/verify_test.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2020-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2024, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -463,7 +463,7 @@ func TestNewVerifier(t *testing.T) { //nolint:maintidx
 
 	kr := openpgp.EntityList{getTestEntity(t)}
 
-	cb := func(r VerifyResult) bool { return false }
+	cb := func(_ VerifyResult) bool { return false }
 
 	tests := []struct {
 		name          string

--- a/pkg/sif/descriptor_input.go
+++ b/pkg/sif/descriptor_input.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2021-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2024, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -99,7 +99,7 @@ func OptObjectTime(t time.Time) DescriptorInputOpt {
 
 // OptMetadata marshals metadata from md into the "extra" field of d.
 func OptMetadata(md encoding.BinaryMarshaler) DescriptorInputOpt {
-	return func(t DataType, opts *descriptorOpts) error {
+	return func(_ DataType, opts *descriptorOpts) error {
 		opts.md = md
 		return nil
 	}

--- a/pkg/siftool/del.go
+++ b/pkg/siftool/del.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2024, Sylabs Inc. All rights reserved.
 // Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 // Copyright (c) 2017, Yannick Cote <yhcote@gmail.com> All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -27,7 +27,7 @@ func (c *command) getDel() *cobra.Command {
 		Example: c.opts.rootPath + " del 1 image.sif",
 		Args:    cobra.ExactArgs(2),
 		PreRunE: c.initApp,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			id, err := strconv.ParseUint(args[0], 10, 32)
 			if err != nil {
 				return fmt.Errorf("while converting id: %w", err)

--- a/pkg/siftool/dump.go
+++ b/pkg/siftool/dump.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2024, Sylabs Inc. All rights reserved.
 // Copyright (c) 2018, Divya Cote <divya.cote@gmail.com> All rights reserved.
 // Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 // Copyright (c) 2017, Yannick Cote <yhcote@gmail.com> All rights reserved.
@@ -28,7 +28,7 @@ func (c *command) getDump() *cobra.Command {
 		Example: c.opts.rootPath + " dump 1 image.sif",
 		Args:    cobra.ExactArgs(2),
 		PreRunE: c.initApp,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			id, err := strconv.ParseUint(args[0], 10, 32)
 			if err != nil {
 				return fmt.Errorf("while converting id: %w", err)

--- a/pkg/siftool/header.go
+++ b/pkg/siftool/header.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2024, Sylabs Inc. All rights reserved.
 // Copyright (c) 2018, Divya Cote <divya.cote@gmail.com> All rights reserved.
 // Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 // Copyright (c) 2017, Yannick Cote <yhcote@gmail.com> All rights reserved.
@@ -25,7 +25,7 @@ func (c *command) getHeader() *cobra.Command {
 		Example: c.opts.rootPath + " header image.sif",
 		Args:    cobra.ExactArgs(1),
 		PreRunE: c.initApp,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			return c.app.Header(args[0])
 		},
 		DisableFlagsInUseLine: true,

--- a/pkg/siftool/info.go
+++ b/pkg/siftool/info.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2024, Sylabs Inc. All rights reserved.
 // Copyright (c) 2018, Divya Cote <divya.cote@gmail.com> All rights reserved.
 // Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 // Copyright (c) 2017, Yannick Cote <yhcote@gmail.com> All rights reserved.
@@ -29,7 +29,7 @@ func (c *command) getInfo() *cobra.Command {
 		Example: c.opts.rootPath + " info 1 image.sif",
 		Args:    cobra.ExactArgs(2),
 		PreRunE: c.initApp,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			id, err := strconv.ParseUint(args[0], 10, 32)
 			if err != nil {
 				return fmt.Errorf("while converting id: %w", err)

--- a/pkg/siftool/list.go
+++ b/pkg/siftool/list.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2024, Sylabs Inc. All rights reserved.
 // Copyright (c) 2018, Divya Cote <divya.cote@gmail.com> All rights reserved.
 // Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 // Copyright (c) 2017, Yannick Cote <yhcote@gmail.com> All rights reserved.
@@ -25,7 +25,7 @@ func (c *command) getList() *cobra.Command {
 		Example: c.opts.rootPath + " list image.sif",
 		Args:    cobra.ExactArgs(1),
 		PreRunE: c.initApp,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			return c.app.List(args[0])
 		},
 		DisableFlagsInUseLine: true,

--- a/pkg/siftool/new.go
+++ b/pkg/siftool/new.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2024, Sylabs Inc. All rights reserved.
 // Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 // Copyright (c) 2017, Yannick Cote <yhcote@gmail.com> All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -24,7 +24,7 @@ func (c *command) getNew() *cobra.Command {
 		Example: c.opts.rootPath + " new image.sif",
 		Args:    cobra.ExactArgs(1),
 		PreRunE: c.initApp,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			return c.app.New(args[0])
 		},
 		DisableFlagsInUseLine: true,

--- a/pkg/siftool/setprim.go
+++ b/pkg/siftool/setprim.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2024, Sylabs Inc. All rights reserved.
 // Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 // Copyright (c) 2017, Yannick Cote <yhcote@gmail.com> All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -27,7 +27,7 @@ func (c *command) getSetPrim() *cobra.Command {
 		Example: c.opts.rootPath + " setprim 1 image.sif",
 		Args:    cobra.ExactArgs(2),
 		PreRunE: c.initApp,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			id, err := strconv.ParseUint(args[0], 10, 32)
 			if err != nil {
 				return fmt.Errorf("while converting id: %w", err)


### PR DESCRIPTION
This updates to the sylabs/sif v2.15.2 by pulling in
- sylabs/sif#350
- sylabs/sif#352

the latter of which had a PR description of
> `revive` linter now checks for this as of v1.3.7.